### PR TITLE
Check player before polling progress

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -23,6 +23,7 @@ const player = ref(null);
 const ready = ref(false);
 const isPlaying = ref(false);
 provide('ytPlayer', player);
+provide('ytReady', ready);
 
 function loadScript() {
   return new Promise((resolve) => {

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -5,21 +5,41 @@
 </template>
 
 <script setup>
-import { onMounted, ref, inject } from 'vue';
+import { onMounted, ref, inject, watch } from 'vue';
 import { useClips } from '../stores/clips';
 
 const { clips, current } = useClips();
 const percent = ref(0);
 const player = inject('ytPlayer');
+const ready = inject('ytReady');
+let timer = null;
 
-onMounted(() => {
-  setInterval(() => {
+function startInterval() {
+  if (timer) return;
+  timer = setInterval(() => {
     const clip = clips.value[current.value];
     if (player?.value && clip && player.value.getCurrentTime) {
       const t = player.value.getCurrentTime();
       percent.value = ((t - clip.start) / (clip.end - clip.start)) * 100;
     }
   }, 500);
+}
+
+onMounted(() => {
+  if (ready?.value) {
+    startInterval();
+  } else if (ready) {
+    const stop = watch(
+      ready,
+      (val) => {
+        if (val) {
+          startInterval();
+          stop();
+        }
+      },
+      { immediate: false }
+    );
+  }
 });
 
 function seek(e) {


### PR DESCRIPTION
## Summary
- expose a `ytReady` ref from `Player.vue`
- start the progress polling interval only after the player is ready
- guard the interval logic with checks for the player instance and the current clip

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855521b67048329a6fd139ef7d5720b