### PR TITLE
Add playlist save and draggable seeking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 1. **Add a clip** – Paste a YouTube URL or just the ID. The app extracts the ID automatically and shows a thumbnail preview.
 2. **Set the range** – Enter start and end times in seconds. Both must be at least 1 and the end must exceed the start by at least one second.
-3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** to apply changes or **Back** to restore the current playlist.
+3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** (above the share link) to apply changes or **Back** to restore the current playlist. Saving restarts the player.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking. If you scrub the built‑in YouTube bar, the custom progress pauses and resumes automatically once the video starts playing again.
+5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. Hovering or dragging shows a thumbnail preview of that moment. If you scrub the built‑in YouTube bar, the custom progress pauses and resumes automatically once the video starts playing again.
 6. **Share** – A readonly input field with a copy button encodes your clips into the URL. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
@@ -28,6 +28,7 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 - **Segment selection** – start/end fields require a minimum of one second and the end must be greater than the start.
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
+- **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview that appears while hovering or dragging.
 - **Skip controls** – Next and Prev buttons jump between clips. The Prev button resets the current clip on first press and moves back if pressed again within two seconds.
 - **Custom progress** – the bar pauses when the YouTube progress is dragged so manual seeking doesn't affect splice playback and resumes once the video plays.
 - **Save or revert** – edit clips freely and press **Save** to restart the playlist or **Back** to discard changes.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 1. **Add a clip** – Paste a YouTube URL. The app extracts the video ID and shows a thumbnail preview.
 2. **Set the range** – Enter the start and end times in seconds for the portion you want to include.
-3. **Arrange clips** – Add as many segments as you like. Drag the buttons to reorder or remove items from the list. Press **Save** to store the current playlist.
+3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** (above the share box) to store your playlist locally.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Press play to watch the combined result directly in the page. The progress bar shows dark lines for each clip and a red dot for the current time. Dragging the dot displays a timestamp and preview image.
-6. **Share** – There's a readonly input with a copy button that generates a link encoding your clips so others can open the same splice. A short‑link option can be added later.
+5. **Play** – Press play to watch the combined result. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking.
+6. **Share** – Below the **Save** button is a readonly input with a copy button that encodes your clips into the URL. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
 
@@ -30,6 +30,7 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
 - **Sharing** – generates a link containing your clip list so others can view the same splice or load it directly.
 - **Local save** – store your playlist in the browser and restore it automatically when you return.
+- **Watch progress** – the last watched time is saved so you can resume later.
 - **Drag to reorder** – rearrange clips in the list using standard drag-and-drop.
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 ## Usage
 
-1. **Add a clip** – Paste a YouTube URL or just the video ID. A thumbnail preview will appear.
-2. **Set the range** – Enter the start and end times in seconds for the portion you want to include. Each clip must be at least one second long.
+1. **Add a clip** – Paste a YouTube URL or just the ID. The app extracts the ID automatically and shows a thumbnail preview.
+2. **Set the range** – Enter start and end times in seconds. Both must be at least 1 and the end must exceed the start by at least one second.
 3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** to apply changes or **Back** to restore the current playlist.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
 5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking. If you scrub the built‑in YouTube bar, the custom progress pauses and resumes automatically once the video starts playing again.
@@ -24,8 +24,8 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 
 ### Features
 
-- **Video input and management** – accepts either full YouTube URLs or bare video IDs and shows thumbnails.
-- **Segment selection** – start/end times with validation so end must be greater than start and each clip lasts at least one second.
+- **Video input and management** – accepts URLs or IDs, automatically stores only the ID and shows thumbnails.
+- **Segment selection** – start/end fields require a minimum of one second and the end must be greater than the start.
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
 - **Skip controls** – Next and Prev buttons jump between clips. The Prev button resets the current clip on first press and moves back if pressed again within two seconds.
@@ -60,6 +60,7 @@ the `src/` directory:
 - `components/` – smaller UI pieces
 - `assets/` – CSS and other static files
 - `stores/` – Pinia store modules
+- `utils/` – helpers such as `youtube.js` for converting between URLs and video IDs
 
 Keeping the code under `src/` helps separate source from configuration and
 build output while still allowing the README to live in the project root.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 ## Usage
 
-1. **Add a clip** – Paste a YouTube URL. The app extracts the video ID and shows a thumbnail preview.
-2. **Set the range** – Enter the start and end times in seconds for the portion you want to include.
-3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items.
+1. **Add a clip** – Paste a YouTube URL or just the video ID. A thumbnail preview will appear.
+2. **Set the range** – Enter the start and end times in seconds for the portion you want to include. Each clip must be at least one second long.
+3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** to apply changes or **Back** to restore the current playlist.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking. Using YouTube's own controls while a video plays does not update the custom bar until **Play** is pressed again.
+5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking. If you scrub the built‑in YouTube bar, the custom progress pauses and resumes automatically once the video starts playing again.
 6. **Share** – A readonly input field with a copy button encodes your clips into the URL. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
@@ -24,12 +24,13 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 
 ### Features
 
-- **Video input and management** – accepts different forms of YouTube URLs and shows thumbnails.
-- **Segment selection** – start/end times with validation so end must be greater than start.
+- **Video input and management** – accepts either full YouTube URLs or bare video IDs and shows thumbnails.
+- **Segment selection** – start/end times with validation so end must be greater than start and each clip lasts at least one second.
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
 - **Skip controls** – Next and Prev buttons jump between clips. The Prev button resets the current clip on first press and moves back if pressed again within two seconds.
-- **Custom progress** – the bar pauses when the YouTube progress is dragged so manual seeking doesn't affect splice playback.
+- **Custom progress** – the bar pauses when the YouTube progress is dragged so manual seeking doesn't affect splice playback and resumes once the video plays.
+- **Save or revert** – edit clips freely and press **Save** to restart the playlist or **Back** to discard changes.
 - **Sharing** – generates a link containing your clip list so others can view the same splice or load it directly.
 - **Drag to reorder** – rearrange clips in the list using standard drag-and-drop.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 2. **Set the range** – Enter the start and end times in seconds for the portion you want to include.
 3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Use the Play button to watch the combined result or Pause to stop. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking.
+5. **Play** – Use the Play button to watch the combined result or Pause to stop. Skip forward or back with Next/Prev buttons. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking. Using YouTube's own controls while a video plays does not update the custom bar until **Play** is pressed again.
 6. **Share** – A readonly input field with a copy button encodes your clips into the URL. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
@@ -28,6 +28,8 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 - **Segment selection** – start/end times with validation so end must be greater than start.
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
+- **Skip controls** – Next and Prev buttons jump between clips. The Prev button resets the current clip on first press and moves back if pressed again within two seconds.
+- **Custom progress** – the bar pauses when the YouTube progress is dragged so manual seeking doesn't affect splice playback.
 - **Sharing** – generates a link containing your clip list so others can view the same splice or load it directly.
 - **Drag to reorder** – rearrange clips in the list using standard drag-and-drop.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 1. **Add a clip** – Paste a YouTube URL. The app extracts the video ID and shows a thumbnail preview.
 2. **Set the range** – Enter the start and end times in seconds for the portion you want to include.
-3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items. Use **Save** (above the share box) to store your playlist locally.
+3. **Arrange clips** – Add as many segments as you like. Each entry shows editable ID, start and end fields. Drag the icon to reorder or remove items.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Press play to watch the combined result. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking.
-6. **Share** – Below the **Save** button is a readonly input with a copy button that encodes your clips into the URL. A short‑link option can be added later.
+5. **Play** – Use the Play button to watch the combined result or Pause to stop. Dragging the progress handle pauses playback; press **Play** again to continue from that spot. The bar displays clip boundaries, a red dot and a thumbnail preview while seeking.
+6. **Share** – A readonly input field with a copy button encodes your clips into the URL. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
 
@@ -29,8 +29,6 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
 - **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
 - **Sharing** – generates a link containing your clip list so others can view the same splice or load it directly.
-- **Local save** – store your playlist in the browser and restore it automatically when you return.
-- **Watch progress** – the last watched time is saved so you can resume later.
 - **Drag to reorder** – rearrange clips in the list using standard drag-and-drop.
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ YouTube Splicer lets you combine several portions of different YouTube videos an
 
 1. **Add a clip** – Paste a YouTube URL. The app extracts the video ID and shows a thumbnail preview.
 2. **Set the range** – Enter the start and end times in seconds for the portion you want to include.
-3. **Arrange clips** – Add as many segments as you like. Drag to reorder or remove items from the list.
+3. **Arrange clips** – Add as many segments as you like. Drag the buttons to reorder or remove items from the list. Press **Save** to store the current playlist.
 4. **Player at the top** – The page always displays a player area above the list. It stays empty until you add the first clip.
-5. **Play** – Press play to watch the combined result directly in the page.
-6. **Share** – Generate a shareable link that encodes your clip list in the URL so others can view the same splice. A short‑link option can be added later.
+5. **Play** – Press play to watch the combined result directly in the page. The progress bar shows dark lines for each clip and a red dot for the current time. Dragging the dot displays a timestamp and preview image.
+6. **Share** – There's a readonly input with a copy button that generates a link encoding your clips so others can open the same splice. A short‑link option can be added later.
 
 This project is built with Vite, Vue 3 and Tailwind CSS. Clips are stored in an array using the format:
 
@@ -27,8 +27,10 @@ When you click **Share**, this array is encoded (JSON → `id,start,end|…` →
 - **Video input and management** – accepts different forms of YouTube URLs and shows thumbnails.
 - **Segment selection** – start/end times with validation so end must be greater than start.
 - **Playback sequencing** – uses the YouTube Iframe API to queue clips and automatically jump to the next section when one finishes.
-- **Progress bar** – displays a bar with markers showing where each segment starts and allows seeking.
-- **Sharing** – generates a link containing your clip list so others can view the same splice.
+- **Progress bar** – displays progress across the full playlist with segment markers, a draggable handle and thumbnail preview.
+- **Sharing** – generates a link containing your clip list so others can view the same splice or load it directly.
+- **Local save** – store your playlist in the browser and restore it automatically when you return.
+- **Drag to reorder** – rearrange clips in the list using standard drag-and-drop.
 
 ### Development
 
@@ -67,7 +69,7 @@ The project implements the features outlined in the original requirements:
 - **影片輸入與管理** – paste various YouTube URL formats; the ID is extracted and a thumbnail is shown.
 - **區段設定** – start/end inputs with validation and an option to reset to the full video length.
 - **播放拼接** – clips play sequentially using the Iframe API.
-- **播放控制與進度條標記** – basic controls and a progress bar marked with clip boundaries.
+- **播放控制與進度條標記** – basic controls with a progress bar, draggable handle and thumbnail preview.
 - **預覽縮圖顯示** – video thumbnails appear in the clip list.
 - **分享機制** – encoded parameter URLs, with short links available via a simple API.
 - **響應式設計** – layout adapts from desktop to mobile.

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <h1 class="text-2xl font-bold mb-4">YouTube Splicer</h1>
     <div class="flex flex-col md:flex-row">
       <div class="md:w-2/3">
-        <Player />
+        <Player ref="playerRef" />
       </div>
       <div class="md:w-1/3 md:pl-4 mt-4 md:mt-0">
         <ClipManager />
@@ -13,6 +13,13 @@
 </template>
 
 <script setup>
+import { ref, provide } from 'vue'
 import ClipManager from './components/ClipManager.vue'
 import Player from './components/Player.vue'
+
+const playerRef = ref(null)
+function restart() {
+  playerRef.value?.startPlaylist()
+}
+provide('startPlaylist', restart)
 </script>

--- a/src/components/ClipManager.vue
+++ b/src/components/ClipManager.vue
@@ -37,11 +37,9 @@
       </li>
     </ul>
 
-    <button
-      v-if="clips.length"
-      @click="saveLocal"
-      class="bg-green-500 text-white px-2 py-1 mt-4"
-    >Save</button>
+    <div v-if="clips.length" class="mt-4 text-sm text-gray-500">
+      Playlist changes are encoded into the share link below.
+    </div>
 
     <div v-if="shareUrl" class="mt-2 flex items-center space-x-2">
       <input ref="shareInput" type="text" readonly :value="shareUrl" class="flex-1 border p-1" />
@@ -60,7 +58,7 @@ const start = ref(0);
 const end = ref(0);
 const clipStore = useClips();
 const { clips } = storeToRefs(clipStore);
-const { add, remove, move, encode, saveLocal: saveToLocal } = clipStore;
+const { add, remove, move, encode } = clipStore;
 const dragging = ref(null);
 const shareInput = ref(null);
 
@@ -115,8 +113,4 @@ function copyLink() {
   document.execCommand('copy');
 }
 
-function saveLocal() {
-  saveToLocal();
-  alert('Playlist saved');
-}
 </script>

--- a/src/components/ClipManager.vue
+++ b/src/components/ClipManager.vue
@@ -20,22 +20,32 @@
       <li
         v-for="(clip, i) in clips"
         :key="i"
-        class="flex items-center space-x-2"
+        class="flex items-center space-x-2 p-1 group hover:bg-gray-100"
         draggable="true"
         @dragstart="dragStart(i)"
         @dragover.prevent
         @drop="drop(i)"
       >
+        <span class="cursor-move text-gray-500 group-hover:text-gray-700">&#x2630;</span>
         <img :src="thumb(clip.id)" class="w-20 h-12 object-cover" />
-        <span class="flex-1">{{ clip.id }} [{{ clip.start }}-{{ clip.end }}]</span>
+        <input v-model="clip.id" class="border p-1 w-28" />
+        <label class="text-sm">Start:</label>
+        <input v-model.number="clip.start" type="number" class="border p-1 w-16" />
+        <label class="text-sm">End:</label>
+        <input v-model.number="clip.end" type="number" class="border p-1 w-16" />
         <button @click="remove(i)" class="text-red-500">x</button>
       </li>
     </ul>
 
-    <div v-if="shareUrl" class="mt-4 flex items-center space-x-2">
+    <button
+      v-if="clips.length"
+      @click="saveLocal"
+      class="bg-green-500 text-white px-2 py-1 mt-4"
+    >Save</button>
+
+    <div v-if="shareUrl" class="mt-2 flex items-center space-x-2">
       <input ref="shareInput" type="text" readonly :value="shareUrl" class="flex-1 border p-1" />
       <button @click="copyLink" class="bg-gray-200 px-2 py-1">Copy</button>
-      <button @click="saveLocal" class="bg-green-500 text-white px-2 py-1">Save</button>
     </div>
   </div>
 </template>

--- a/src/components/ClipManager.vue
+++ b/src/components/ClipManager.vue
@@ -3,15 +3,32 @@
     <form @submit.prevent="addClip" class="flex items-end space-x-2">
       <div>
         <label class="block text-sm">YouTube URL</label>
-        <input v-model="url" type="text" class="border p-1" />
+        <input
+          v-model="url"
+          @blur="url = urlToId(url)"
+          type="text"
+          class="border p-1"
+        />
       </div>
       <div>
         <label class="block text-sm">Start (s)</label>
-        <input v-model.number="start" type="number" min="1" step="1" class="border p-1 w-20" />
+        <input
+          v-model.number="start"
+          type="number"
+          min="1"
+          step="1"
+          :class="['border p-1 w-20', start < 1 ? 'border-red-500' : '']"
+        />
       </div>
       <div>
         <label class="block text-sm">End (s)</label>
-        <input v-model.number="end" type="number" min="1" step="1" class="border p-1 w-20" />
+        <input
+          v-model.number="end"
+          type="number"
+          min="1"
+          step="1"
+          :class="['border p-1 w-20', addInvalid ? 'border-red-500' : '']"
+        />
       </div>
       <button type="submit" class="bg-blue-500 text-white px-2 py-1">Add</button>
     </form>
@@ -62,6 +79,7 @@ import { urlToId } from '../utils/youtube';
 const url = ref('');
 const start = ref(1);
 const end = ref(1);
+const addInvalid = computed(() => start.value < 1 || end.value < 1 || end.value <= start.value);
 const clipStore = useClips();
 const { clips } = storeToRefs(clipStore);
 const { encode, setClips } = clipStore;

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -228,7 +228,6 @@ async function startPlaylist() {
 
 provide('ytPlayer', activePlayer)
 provide('playSegment', playSegment)
-provide('startPlaylist', startPlaylist)
 
 onMounted(() => {
   if (clips.value.length) startPlaylist()
@@ -237,4 +236,6 @@ onMounted(() => {
 watch(clips, (n, o) => {
   if (n.length && !o.length) startPlaylist()
 })
+
+defineExpose({ startPlaylist })
 </script>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -132,6 +132,7 @@ async function startPlaylist() {
 }
 
 provide('ytPlayer', activePlayer)
+provide('playSegment', playSegment)
 
 onMounted(() => {
   if (clips.value.length) startPlaylist()

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -3,7 +3,10 @@
     <div id="player1" class="w-full aspect-video mb-2"></div>
     <div id="player2" class="w-full aspect-video mb-2" style="display:none"></div>
     <ProgressBar class="mt-2" />
-    <button @click="startPlaylist" class="bg-green-500 text-white px-4 py-1 mt-2">Play</button>
+    <div class="mt-2 space-x-2">
+      <button @click="play" class="bg-green-500 text-white px-4 py-1">Play</button>
+      <button @click="pause" class="bg-gray-500 text-white px-4 py-1">Pause</button>
+    </div>
   </div>
 </template>
 
@@ -14,12 +17,13 @@ import { useClips } from '../stores/clips'
 import { storeToRefs } from 'pinia'
 
 const clipStore = useClips()
-const { clips } = storeToRefs(clipStore)
-const { setCurrent, reset } = clipStore
+const { clips, tracking, progress, current } = storeToRefs(clipStore)
+const { setCurrent, reset, pauseTracking, resumeTracking, offsets, totalDuration, setProgress } = clipStore
 
 let players = [null, null]
 const playerReady = [false, false]
 const activePlayer = ref(null)
+const playing = ref(false)
 let apiReady = false
 let endChecker = null
 const currentPlayer = ref(0)
@@ -41,7 +45,8 @@ function createPlayers() {
     videoId: '',
     playerVars: { origin: location.origin },
     events: {
-      onReady: () => (playerReady[0] = true)
+      onReady: () => (playerReady[0] = true),
+      onStateChange: handleState
     }
   })
   players[1] = new YT.Player('player2', {
@@ -50,9 +55,46 @@ function createPlayers() {
     videoId: '',
     playerVars: { origin: location.origin },
     events: {
-      onReady: () => (playerReady[1] = true)
+      onReady: () => (playerReady[1] = true),
+      onStateChange: handleState
     }
   })
+}
+
+function handleState(event) {
+  if (event.data === YT.PlayerState.PAUSED) {
+    if (activePlayer.value && activePlayer.value.getCurrentTime) {
+      const list = Array.isArray(clips.value) ? clips.value : []
+      const clip = list[current.value]
+      if (clip) {
+        const t = activePlayer.value.getCurrentTime()
+        const elapsed = offsets()[current.value] + (t - clip.start)
+        setProgress(elapsed)
+      }
+    }
+    pauseTracking()
+    playing.value = false
+  }
+}
+
+function seekByProgress(sec) {
+  const list = Array.isArray(clips.value) ? clips.value : []
+  const offs = offsets()
+  let acc = 0
+  for (let i = 0; i < list.length; i++) {
+    const dur = list[i].end - list[i].start
+    if (sec < acc + dur) {
+      if (i !== current.value) {
+        playSegment(i)
+      }
+      const pos = list[i].start + (sec - acc)
+      if (activePlayer.value) {
+        activePlayer.value.seekTo(pos, true)
+      }
+      break
+    }
+    acc += dur
+  }
 }
 
 async function init() {
@@ -114,6 +156,25 @@ function playSegment(idx) {
   }, 100)
 }
 
+function play() {
+  if (!activePlayer.value) {
+    startPlaylist()
+  } else {
+    seekByProgress(progress.value)
+    activePlayer.value.playVideo()
+  }
+  playing.value = true
+  resumeTracking()
+}
+
+function pause() {
+  if (activePlayer.value && activePlayer.value.pauseVideo) {
+    activePlayer.value.pauseVideo()
+    pauseTracking()
+    playing.value = false
+  }
+}
+
 async function startPlaylist() {
   if (!clips.value.length) return
   clearInterval(endChecker)
@@ -129,6 +190,8 @@ async function startPlaylist() {
   reset()
   currentPlayer.value = 0
   playSegment(0)
+  resumeTracking()
+  playing.value = true
 }
 
 provide('ytPlayer', activePlayer)

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -68,6 +68,9 @@ function handleState(event) {
   if (event.data === YT.PlayerState.PAUSED) {
     pauseTracking()
     playing.value = false
+  } else if (event.data === YT.PlayerState.PLAYING) {
+    resumeTracking()
+    playing.value = true
   }
 }
 
@@ -216,6 +219,7 @@ async function startPlaylist() {
     }, 50)
   })
   reset()
+  setProgress(0)
   currentPlayer.value = 0
   playSegment(0)
   resumeTracking()
@@ -224,6 +228,7 @@ async function startPlaylist() {
 
 provide('ytPlayer', activePlayer)
 provide('playSegment', playSegment)
+provide('startPlaylist', startPlaylist)
 
 onMounted(() => {
   if (clips.value.length) startPlaylist()

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -50,6 +50,10 @@ onMounted(() => {
     if (player?.value && clip && player.value.getCurrentTime) {
       const t = player.value.getCurrentTime()
       const elapsed = offsets()[current.value] + (t - clip.start)
+      if (Math.abs(elapsed - progress.value) > 1) {
+        pauseTracking()
+        return
+      }
       setProgress(elapsed)
     }
   }, 500)

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -1,6 +1,25 @@
 <template>
-  <div class="h-2 bg-gray-300 relative" @click="seek($event)">
-    <div class="h-full bg-blue-500" :style="{ width: percent + '%' }"></div>
+  <div class="h-2 bg-gray-300 relative" ref="bar" @click="seek($event)">
+    <div class="h-full bg-red-600" :style="{ width: percent + '%' }"></div>
+    <div
+      v-for="(off, idx) in offsets().slice(1)"
+      :key="idx"
+      class="absolute top-0 bottom-0 w-0.5 bg-gray-700 opacity-80"
+      :style="{ left: (off / totalDuration() * 100) + '%' }"
+    ></div>
+    <div
+      class="absolute -top-1.5 w-3 h-3 rounded-full bg-white border border-gray-700 cursor-pointer"
+      :style="{ left: `calc(${percent}% - 0.375rem)` }"
+      @mousedown.prevent="dragStart"
+    ></div>
+    <div
+      v-if="preview.show"
+      class="absolute -top-24 -translate-x-1/2"
+      :style="{ left: preview.left }"
+    >
+      <img :src="preview.img" class="w-32 h-18 object-cover border" />
+      <div class="text-xs bg-black text-white text-center">{{ preview.time }}</div>
+    </div>
   </div>
 </template>
 
@@ -11,8 +30,13 @@ import { storeToRefs } from 'pinia';
 
 const clipStore = useClips();
 const { clips, current } = storeToRefs(clipStore);
+const { offsets, totalDuration } = clipStore;
 const percent = ref(0);
 const player = inject('ytPlayer');
+const playSegment = inject('playSegment');
+const bar = ref(null);
+const preview = ref({ show: false, left: '0%', img: '', time: '' });
+let dragging = false;
 let timer = null;
 
 onMounted(() => {
@@ -21,7 +45,8 @@ onMounted(() => {
     const clip = list[current.value]
     if (player?.value && clip && player.value.getCurrentTime) {
       const t = player.value.getCurrentTime()
-      percent.value = ((t - clip.start) / (clip.end - clip.start)) * 100
+      const elapsed = offsets()[current.value] + (t - clip.start)
+      percent.value = (elapsed / totalDuration()) * 100
     }
   }, 500)
 })
@@ -30,15 +55,82 @@ onBeforeUnmount(() => {
   clearInterval(timer)
 })
 
-function seek(e) {
-  if (!player?.value) return;
-  const rect = e.currentTarget.getBoundingClientRect();
-  const ratio = (e.clientX - rect.left) / rect.width;
+function formatTime(s) {
+  const m = Math.floor(s / 60)
+  const sec = Math.floor(s % 60)
+  return `${m}:${sec.toString().padStart(2, '0')}`
+}
+
+function updatePreview(clientX) {
+  if (!bar.value) return
+  const rect = bar.value.getBoundingClientRect()
+  let ratio = (clientX - rect.left) / rect.width
+  ratio = Math.max(0, Math.min(1, ratio))
+  const total = totalDuration()
+  const target = ratio * total
+  let acc = 0
   const list = Array.isArray(clips.value) ? clips.value : []
-  const clip = list[current.value]
-  if (clip) {
-    const sec = clip.start + ratio * (clip.end - clip.start)
-    player.value.seekTo(sec, true)
+  for (let i = 0; i < list.length; i++) {
+    const dur = list[i].end - list[i].start
+    if (target < acc + dur) {
+      preview.value.img = `https://img.youtube.com/vi/${list[i].id}/hqdefault.jpg`
+      break
+    }
+    acc += dur
   }
+  preview.value.time = formatTime(target)
+  preview.value.left = `${ratio * 100}%`
+}
+
+function dragStart(e) {
+  dragging = true
+  preview.value.show = true
+  updatePreview(e.clientX)
+  document.addEventListener('mousemove', dragMove)
+  document.addEventListener('mouseup', dragEnd)
+}
+
+function dragMove(e) {
+  if (!dragging) return
+  updatePreview(e.clientX)
+}
+
+function dragEnd(e) {
+  if (!dragging) return
+  dragging = false
+  preview.value.show = false
+  document.removeEventListener('mousemove', dragMove)
+  document.removeEventListener('mouseup', dragEnd)
+  seekAtPosition(e.clientX)
+}
+
+function seekAtPosition(clientX) {
+  if (!player?.value || !bar.value) return
+  const rect = bar.value.getBoundingClientRect()
+  const ratio = (clientX - rect.left) / rect.width
+  seekAt(ratio)
+}
+
+function seekAt(ratio) {
+  const list = Array.isArray(clips.value) ? clips.value : []
+  const target = ratio * totalDuration()
+  let acc = 0
+  for (let i = 0; i < list.length; i++) {
+    const dur = list[i].end - list[i].start
+    if (target < acc + dur) {
+      if (i !== current.value && playSegment) {
+        playSegment(i)
+      }
+      const sec = list[i].start + (target - acc)
+      player.value.seekTo(sec, true)
+      break
+    }
+    acc += dur
+  }
+}
+
+function seek(e) {
+  if (!bar.value) return
+  seekAtPosition(e.clientX)
 }
 </script>

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="h-2 bg-gray-300 relative" ref="bar" @click="seek($event)">
+  <div
+    class="h-2 bg-gray-300 relative"
+    ref="bar"
+    @click="seek($event)"
+    @mousemove="hoverMove"
+    @mouseenter="hoverEnter"
+    @mouseleave="hoverLeave"
+  >
     <div class="h-full bg-red-600" :style="{ width: percent + '%' }"></div>
     <div
       v-for="(off, idx) in offsets().slice(1)"
@@ -114,6 +121,25 @@ function dragEnd(e) {
   document.removeEventListener('mousemove', dragMove)
   document.removeEventListener('mouseup', dragEnd)
   seekAtPosition(e.clientX, false)
+}
+
+function hoverEnter(e) {
+  if (!dragging) {
+    preview.value.show = true
+    updatePreview(e.clientX)
+  }
+}
+
+function hoverMove(e) {
+  if (!dragging && preview.value.show) {
+    updatePreview(e.clientX)
+  }
+}
+
+function hoverLeave() {
+  if (!dragging) {
+    preview.value.show = false
+  }
 }
 
 function seekAtPosition(clientX, play = true) {

--- a/src/main.js
+++ b/src/main.js
@@ -8,15 +8,12 @@ const app = createApp(App);
 const pinia = createPinia();
 app.use(pinia);
 
-// Load clip list from URL or local storage if provided
+// Load clip list from URL if provided
 const params = new URLSearchParams(window.location.search);
 const encoded = params.get('data');
 const store = useClips(pinia);
 if (encoded) {
   store.loadEncoded(encoded);
-} else {
-  store.loadLocal();
 }
-store.loadProgress();
 
 app.mount('#app');

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,20 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
 import './assets/main.css';
+import { useClips } from './stores/clips';
 
 const app = createApp(App);
-app.use(createPinia());
+const pinia = createPinia();
+app.use(pinia);
+
+// Load clip list from URL or local storage if provided
+const params = new URLSearchParams(window.location.search);
+const encoded = params.get('data');
+const store = useClips(pinia);
+if (encoded) {
+  store.loadEncoded(encoded);
+} else {
+  store.loadLocal();
+}
+
 app.mount('#app');

--- a/src/main.js
+++ b/src/main.js
@@ -17,5 +17,6 @@ if (encoded) {
 } else {
   store.loadLocal();
 }
+store.loadProgress();
 
 app.mount('#app');

--- a/src/stores/clips.js
+++ b/src/stores/clips.js
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 export const useClips = defineStore('clips', () => {
   const clips = ref([]);
   const current = ref(0);
+  const progress = ref(0);
 
   function move(oldIndex, newIndex) {
     if (oldIndex === newIndex) return;
@@ -70,6 +71,20 @@ export const useClips = defineStore('clips', () => {
     }
   }
 
+  function setProgress(sec) {
+    progress.value = sec;
+    try {
+      localStorage.setItem('ytsplicer-progress', String(sec));
+    } catch (e) {
+      console.error('Failed to save progress', e);
+    }
+  }
+
+  function loadProgress() {
+    const s = localStorage.getItem('ytsplicer-progress');
+    if (s) progress.value = Number(s) || 0;
+  }
+
   const totalDuration = () =>
     clips.value.reduce((sum, c) => sum + (c.end - c.start), 0);
 
@@ -96,6 +111,9 @@ export const useClips = defineStore('clips', () => {
     loadEncoded,
     saveLocal,
     loadLocal,
+    progress,
+    setProgress,
+    loadProgress,
     totalDuration,
     offsets
   };

--- a/src/stores/clips.js
+++ b/src/stores/clips.js
@@ -20,6 +20,10 @@ export const useClips = defineStore('clips', () => {
     clips.value.push(clip);
   }
 
+  function setClips(list) {
+    clips.value = JSON.parse(JSON.stringify(list));
+  }
+
   function remove(index) {
     clips.value.splice(index, 1);
   }
@@ -91,6 +95,7 @@ export const useClips = defineStore('clips', () => {
     setCurrent,
     reset,
     move,
+    setClips,
     encode,
     loadEncoded,
     progress,

--- a/src/stores/clips.js
+++ b/src/stores/clips.js
@@ -5,6 +5,7 @@ export const useClips = defineStore('clips', () => {
   const clips = ref([]);
   const current = ref(0);
   const progress = ref(0);
+  const tracking = ref(true);
 
   function move(oldIndex, newIndex) {
     if (oldIndex === newIndex) return;
@@ -56,33 +57,16 @@ export const useClips = defineStore('clips', () => {
     }
   }
 
-  function saveLocal() {
-    try {
-      localStorage.setItem('ytsplicer', encode());
-    } catch (e) {
-      console.error('Failed to save playlist', e);
-    }
-  }
-
-  function loadLocal() {
-    const str = localStorage.getItem('ytsplicer');
-    if (str) {
-      loadEncoded(str);
-    }
-  }
-
   function setProgress(sec) {
     progress.value = sec;
-    try {
-      localStorage.setItem('ytsplicer-progress', String(sec));
-    } catch (e) {
-      console.error('Failed to save progress', e);
-    }
   }
 
-  function loadProgress() {
-    const s = localStorage.getItem('ytsplicer-progress');
-    if (s) progress.value = Number(s) || 0;
+  function pauseTracking() {
+    tracking.value = false;
+  }
+
+  function resumeTracking() {
+    tracking.value = true;
   }
 
   const totalDuration = () =>
@@ -109,12 +93,12 @@ export const useClips = defineStore('clips', () => {
     move,
     encode,
     loadEncoded,
-    saveLocal,
-    loadLocal,
     progress,
     setProgress,
-    loadProgress,
+    pauseTracking,
+    resumeTracking,
     totalDuration,
-    offsets
+    offsets,
+    tracking
   };
 });

--- a/src/utils/youtube.js
+++ b/src/utils/youtube.js
@@ -1,0 +1,20 @@
+export function urlToId(input) {
+  if (!input) return '';
+  try {
+    const url = new URL(input);
+    if (url.hostname.includes('youtu.be')) {
+      return url.pathname.slice(1);
+    }
+    if (url.searchParams.has('v')) {
+      return url.searchParams.get('v');
+    }
+    const parts = url.pathname.split('/');
+    return parts[parts.length - 1];
+  } catch (e) {
+    return input.trim();
+  }
+}
+
+export function idToUrl(id) {
+  return `https://www.youtube.com/watch?v=${id}`;
+}


### PR DESCRIPTION
## Summary
- load stored playlists from localStorage or share URLs
- allow saving the current playlist with a new **Save** button
- add draggable progress handle with preview thumbnail
- enable copy/share and local save from `ClipManager`
- update README for new UX

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685612f85478832984dab11944db4fff